### PR TITLE
Fix runtime environment for docker. The docker run is failing due to obsolete version

### DIFF
--- a/Defra.UI.Tests/docker-compose-grid.yml
+++ b/Defra.UI.Tests/docker-compose-grid.yml
@@ -1,8 +1,3 @@
-# To execute this docker-compose yml file use `docker-compose -f docker-compose-grid.yml up`
-# Add the `-d` flag at the end for detached execution
-# docker compose -f docker-compose-grid.yml up --scale chrome=4
-# To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose-grid.yml down`
-version: "3.6"
 services:
 
   selenium-hub:


### PR DESCRIPTION
Fix runtime environment for docker. The docker run is failing due to obsolete version