### PR TITLE
Fix failing application portal test scripts due to introduction of IDM login types

### DIFF
--- a/Defra.UI.Tests/Defra.UI.Tests.csproj
+++ b/Defra.UI.Tests/Defra.UI.Tests.csproj
@@ -8,9 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Feature\CP\E2E\**" />
     <Compile Remove="Feature\Regression\**" />
+    <EmbeddedResource Remove="Feature\CP\E2E\**" />
     <EmbeddedResource Remove="Feature\Regression\**" />
+    <None Remove="Feature\CP\E2E\**" />
     <None Remove="Feature\Regression\**" />
+    <ReqnrollFeatureFiles Remove="Feature\CP\E2E\**" />
+    <ReqnrollObsoleteCodeBehindFiles Remove="Feature\CP\E2E\**" />
     <SpecFlowFeatureFiles Remove="Feature\Regression\**" />
     <SpecFlowObsoleteCodeBehindFiles Remove="Feature\Regression\**" />
   </ItemGroup>
@@ -258,10 +263,6 @@
       <Visible>$(UsingMicrosoftNETSdk)</Visible>
       <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
     </SpecFlowFeatureFiles>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Feature\CP\E2E\" />
   </ItemGroup>
 	
 

--- a/Defra.UI.Tests/Feature/AP/Accessibility/APAccessibility.feature
+++ b/Defra.UI.Tests/Feature/AP/Accessibility/APAccessibility.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/E2E/DogAndCat.feature
+++ b/Defra.UI.Tests/Feature/AP/E2E/DogAndCat.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/E2E/Ferret.feature
+++ b/Defra.UI.Tests/Feature/AP/E2E/Ferret.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/PTSignificantFeatures.feature
+++ b/Defra.UI.Tests/Feature/AP/PTSignificantFeatures.feature
@@ -7,6 +7,9 @@ Background:
 	Given that I navigate to the DEFRA application
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	And sign in with valid credentials with logininfo
 	

--- a/Defra.UI.Tests/Feature/AP/PetsHomePage.feature
+++ b/Defra.UI.Tests/Feature/AP/PetsHomePage.feature
@@ -7,6 +7,9 @@ Background:
 	Given that I navigate to the DEFRA application
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	And sign in with valid credentials with logininfo
 

--- a/Defra.UI.Tests/Feature/AP/PetsOwnerAddress.feature
+++ b/Defra.UI.Tests/Feature/AP/PetsOwnerAddress.feature
@@ -7,6 +7,9 @@ Background:
 	Given that I navigate to the DEFRA application
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	And sign in with valid credentials with logininfo
 

--- a/Defra.UI.Tests/Feature/AP/PrintDownload/DownloadTravelDocument.feature
+++ b/Defra.UI.Tests/Feature/AP/PrintDownload/DownloadTravelDocument.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/PrintDownload/PrintTravelDocument.feature
+++ b/Defra.UI.Tests/Feature/AP/PrintDownload/PrintTravelDocument.feature
@@ -6,6 +6,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/SignIn.feature
+++ b/Defra.UI.Tests/Feature/AP/SignIn.feature
@@ -7,6 +7,9 @@ Background:
 	Given that I navigate to the DEFRA application
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 
 Scenario: Sign in button click validation

--- a/Defra.UI.Tests/Feature/AP/Update/ManageAccount.feature
+++ b/Defra.UI.Tests/Feature/AP/Update/ManageAccount.feature
@@ -5,6 +5,9 @@ Background:
 	Given that I navigate to the DEFRA application
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	And sign in with valid credentials with logininfo
 

--- a/Defra.UI.Tests/Feature/AP/Update/UpdateMicrochipInformation.feature
+++ b/Defra.UI.Tests/Feature/AP/Update/UpdateMicrochipInformation.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/Update/UpdatePetDetails.feature
+++ b/Defra.UI.Tests/Feature/AP/Update/UpdatePetDetails.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/Update/UpdatePetOwnerDetails.feature
+++ b/Defra.UI.Tests/Feature/AP/Update/UpdatePetOwnerDetails.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/Validations/Microchip Information Validations.feature
+++ b/Defra.UI.Tests/Feature/AP/Validations/Microchip Information Validations.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/Validations/Pet Details Validations.feature
+++ b/Defra.UI.Tests/Feature/AP/Validations/Pet Details Validations.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/AP/Validations/Pet Owner Details Validations.feature
+++ b/Defra.UI.Tests/Feature/AP/Validations/Pet Owner Details Validations.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/CP/E2E.feature
+++ b/Defra.UI.Tests/Feature/CP/E2E.feature
@@ -6,6 +6,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Feature/IDCOMS/IdcomsRegressionE2E.feature
+++ b/Defra.UI.Tests/Feature/IDCOMS/IdcomsRegressionE2E.feature
@@ -7,6 +7,9 @@ Background:
 	Given I navigate to PETS a travel document URL
 	And I have provided the password for Landing page
 	When I click Continue button from Landing page
+	Then I should see type of Gateway login page
+	And I have selected "Sign in with Government Gateway" as login type
+	When I click Continue button from How do you want to sign in page
 	Then I should redirected to the AP Sign in using Government Gateway page
 	When I have provided the credentials and signin
 	Then I should redirected to Apply for a pet travel document page

--- a/Defra.UI.Tests/Hooks/PageHooks.cs
+++ b/Defra.UI.Tests/Hooks/PageHooks.cs
@@ -59,6 +59,8 @@ namespace Defra.UI.Tests.Hooks
             _objectContainer.RegisterInstanceAs(GetBaseWithContainer<SummaryPage, ISummaryPage>());
             _objectContainer.RegisterInstanceAs(GetBaseWithContainer<ManageAccountPage, IManageAccountPage>());
             _objectContainer.RegisterInstanceAs(GetBaseWithContainer<EmailSignUpPage, IEmailSignUpPage>());
+            _objectContainer.RegisterInstanceAs(GetBaseWithContainer<GovernmentGatewayTypePage, IGovernmentGatewayTypePage>());
+            
 
             // CP Testing
             _objectContainer.RegisterInstanceAs(GetBaseWithContainer<SignInCPPage, ISignInCPPage>());

--- a/Defra.UI.Tests/Pages/AP/Classes/GovernmentGatewayTypePage.cs
+++ b/Defra.UI.Tests/Pages/AP/Classes/GovernmentGatewayTypePage.cs
@@ -1,0 +1,54 @@
+﻿using Defra.UI.Tests.Pages.AP.Interfaces;
+using Defra.UI.Tests.Tools;
+using OpenQA.Selenium;
+using Reqnroll.BoDi;
+
+namespace Defra.UI.Tests.Pages.AP.Classes
+{
+    public class GovernmentGatewayTypePage: IGovernmentGatewayTypePage
+    {
+        private IObjectContainer _objectContainer;
+
+        #region Page Objects
+
+        private IWebElement PageHeading => _driver.WaitForElement(By.Id("header"), true);
+
+        private IReadOnlyCollection<IWebElement> rdoLoginTypes => _driver.WaitForElements(By.ClassName("govuk-radios__label"));
+
+        private IWebElement btnContinue => _driver.WaitForElement(By.Id("continueReplacement"));
+
+        #endregion Page Objects
+
+        private IWebDriver _driver => _objectContainer.Resolve<IWebDriver>();
+
+        public GovernmentGatewayTypePage(IObjectContainer container)
+        {
+            _objectContainer = container;
+        }
+
+        public bool IsPageLoaded(string pageName)
+        {
+            return PageHeading.Text.Contains(pageName);
+        }
+
+        public void SelectLoginType(string loginType)
+        {
+            if (rdoLoginTypes.Count > 0)
+            {
+                if (loginType.ToUpper().Contains("SIGN IN WITH GOV UK ONE LOGIN"))
+                {
+                    rdoLoginTypes.ElementAt(0)?.Click();
+                }
+                else if (loginType.ToUpper().Contains("SIGN IN WITH GOVERNMENT GATEWAY"))
+                {
+                    rdoLoginTypes.ElementAt(1)?.Click();
+                }
+            }
+        }
+
+        public void ClickContinueButton()
+        {
+            btnContinue.Click();
+        }
+    }
+}

--- a/Defra.UI.Tests/Pages/AP/Classes/LandingPage.cs
+++ b/Defra.UI.Tests/Pages/AP/Classes/LandingPage.cs
@@ -1,9 +1,8 @@
-﻿using Reqnroll.BoDi;
-using Defra.UI.Tests.Configuration;
+﻿using Defra.UI.Tests.Configuration;
 using Defra.UI.Tests.Pages.AP.Interfaces;
 using Defra.UI.Tests.Tools;
 using OpenQA.Selenium;
-using Microsoft.Dynamics365.UIAutomation.Browser;
+using Reqnroll.BoDi;
 
 namespace Defra.UI.Tests.Pages.AP.Classes
 {
@@ -40,7 +39,6 @@ namespace Defra.UI.Tests.Pages.AP.Classes
             if (txtLogings.Count > 0)
             {
                 txtLogings.FirstOrDefault()?.SendKeys(ConfigSetup.BaseConfiguration.TestConfiguration.EnvAPLogin);
-                btnContinue?.Click();
             }       
             
         }

--- a/Defra.UI.Tests/Pages/AP/Interfaces/IGovernmentGatewayTypePage.cs
+++ b/Defra.UI.Tests/Pages/AP/Interfaces/IGovernmentGatewayTypePage.cs
@@ -1,0 +1,9 @@
+﻿namespace Defra.UI.Tests.Pages.AP.Interfaces
+{
+    public interface IGovernmentGatewayTypePage
+    {
+        bool IsPageLoaded(string pageName);
+        void SelectLoginType(string loginType);
+        void ClickContinueButton();
+    }
+}

--- a/Defra.UI.Tests/Steps/AP/HowDoYouWantToSignInSteps.cs
+++ b/Defra.UI.Tests/Steps/AP/HowDoYouWantToSignInSteps.cs
@@ -1,0 +1,40 @@
+﻿using Defra.UI.Tests.Pages.AP.Classes;
+using Defra.UI.Tests.Pages.AP.Interfaces;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using Reqnroll;
+using Reqnroll.BoDi;
+
+namespace Defra.UI.Tests.Steps.AP
+{
+    [Binding]
+    public class HowDoYouWantToSignInSteps
+    {
+        private readonly IObjectContainer _objectContainer;
+        private IWebDriver? _driver => _objectContainer.IsRegistered<IWebDriver>() ? _objectContainer.Resolve<IWebDriver>() : null;
+        private IGovernmentGatewayTypePage? governmentGatewayTypePage => _objectContainer.IsRegistered<IGovernmentGatewayTypePage>() ? _objectContainer.Resolve<IGovernmentGatewayTypePage>() : null;
+        public HowDoYouWantToSignInSteps(IObjectContainer container)
+        {
+            _objectContainer = container;
+        }
+
+        [Then("I should see type of Gateway login page")]
+        public void ThenIShouldSeeTypeOfGatewayLoginPage()
+        {
+            Assert.True(governmentGatewayTypePage?.IsPageLoaded("How do you want to sign in?"), "How do you want to sign in? page not loaded");
+        }
+
+        [Then("I have selected {string} as login type")]
+        public void ThenIHaveSelectedAsLoginType(string loginType)
+        {
+            governmentGatewayTypePage?.SelectLoginType(loginType);
+        }
+
+        [When("I click Continue button from How do you want to sign in page")]
+        public void WhenIClickContinueButtonFromHowDoYouWantToSignInPage()
+        {
+            governmentGatewayTypePage?.ClickContinueButton();
+        }
+
+    }
+}


### PR DESCRIPTION
Fix failing application portal test scripts due to introduction of IDM login types