### PR TITLE
Pet Owner Address change Welsh to English and vice-versa

### DIFF
--- a/Defra.UI.Tests/Feature/WELSH/Validations/Pet Details Validations Welsh.feature
+++ b/Defra.UI.Tests/Feature/WELSH/Validations/Pet Details Validations Welsh.feature
@@ -507,3 +507,155 @@ Examples:
 	| Are your details correct | MicrochipOption | MicrochipNumber | Pet  | Breed    |
 	| Yes                      | Yes             | 123456789123456 | Ci   | DogBreed |
 	| Yes                      | Yes             | 123456789123456 | Cath | CatBreed |
+
+Scenario Outline: Verify the Welsh language version of each page on selection of Welsh language till the declaration page
+	When I click 'English' link to change the language
+	Then I should navigate to the Pets Owner details correct page
+	When I click 'Cymraeg' link to change the language
+	Then I should navigate to the Pets Owner details correct page in Welsh
+	Then I have selected 'Yes' option
+	When I click on continue button from Are your details correct page in Welsh
+	Then I should redirected to the Is your pet microchipped page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the Is your pet microchipped page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the Is your pet microchipped page in Welsh
+	And I selected the 'No' option
+	When I click Continue button from microchipped page in Welsh
+	Then I should redirected to the Get your pet microchipped before applying page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the Get your pet microchipped before applying page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the Get your pet microchipped before applying page in Welsh
+	And I click on welsh Back button
+	Then I should redirected to the Is your pet microchipped page in Welsh
+	Then I selected the 'Yes' option
+	And provided microchip number as 121212121212442
+	When I click Continue button from microchipped page in Welsh
+	Then I should redirected to When was your pet microchipped or last scanned? page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to When was your pet microchipped or last scanned? page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to When was your pet microchipped or last scanned? page in Welsh
+	And I have provided date of PETS microchipped
+	When I click Continue button from When was your pet microchipped page in Welsh
+	Then I should redirected to the Is your pet a cat, dog or ferret page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the Is your pet a cat, dog or ferret page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the Is your pet a cat, dog or ferret page in Welsh
+	And I have selected an option as 'Ci' for pet in Welsh
+	When I click on continue button from Is your pet a cat, dog or ferret page in Welsh
+	Then I should redirected to the What breed is your 'Ci'? page in Welsh
+	When I click 'English' link to change the language
+	Then I Verify the header of the breed page for 'Dog'
+	When I click 'Cymraeg' link to change the language
+	Then I Verify the header of the breed page for 'Ci' in Welsh
+	And I have provided freetext breed as 'MukuSK' in Welsh
+	When I click on continue button from What is your pet's breed page in Welsh
+	Then I should redirected to the What is your pet's name page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the What is your pet's name page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the What is your pet's name page in Welsh
+	And I provided the Pets name as 'Ci' in Welsh
+	When I click on continue button from What is your pet's name page in Welsh
+	Then I should redirected to the What sex is your pet page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the What sex is your pet page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the What sex is your pet page in Welsh
+	And I have selected the option as 'Male' for sex in Welsh
+	When I click on continue button from What sex is your pet page in Welsh
+	Then I should redirected to the Do you know your pet's date of birth page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the Do you know your pet's date of birth page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the Do you know your pet's date of birth page in Welsh
+	And I have provided date of birth in Welsh
+	When I click on continue button from Do you know your pet's date of birth? page in Welsh
+	Then I should redirected to the What is the main colour of your 'Ci' page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the What is the main colour of your 'Dog' page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the What is the main colour of your 'Ci' page in Welsh
+	And I have selected the option as 'Du' for color in Welsh
+	When I click on continue button from What is the main colour of your pet page in Welsh
+	Then I should redirected to the Does your pet have any significant features page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the Does your pet have any significant features page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the Does your pet have any significant features page in Welsh
+	And I have selected an option as 'Nac oes' for significant features in Welsh
+	When I click on continue button from Does your pet have any significant features page in Welsh
+	Then I should redirected to the Check your answers and sign the declaration page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the Check your answers and sign the declaration page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the Check your answers and sign the declaration page in Welsh
+	And I have ticked the I agree to the declaration checkbox
+	When I click Accept and Send button from Declaration page
+	Then I should redirected to the Application submitted page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the Application submitted page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the Application submitted page in Welsh
+	And I can see the unique application reference number
+	When I have clicked the View all your lifelong pet travel documents link in Welsh
+	Then I should see the heading of dashboard page changed to Welsh
+	And I should see the application in 'Yn aros' status in Welsh
+	When I have clicked the View hyperlink from home page in Welsh
+	Then The submitted application should be displayed in summary view in Welsh
+	When I click 'English' link to change the language
+	Then The submitted application should be displayed in summary view
+	When I click 'Cymraeg' link to change the language
+	Then The submitted application should be displayed in summary view in Welsh
+
+Scenario Outline: Verify the Welsh language version of each page on selection of Welsh language using Manual Address
+	When I click 'English' link to change the language
+	Then I should navigate to the Pets Owner details correct page
+	When I click 'Cymraeg' link to change the language
+	Then I should navigate to the Pets Owner details correct page in Welsh
+	Then I have selected 'No' option
+	When I click on continue button from Are your details correct page in Welsh
+	Then I should redirected to the What is your full name page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the What is your full name page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the What is your full name page in Welsh
+	And I provided the full name of the pet keeper as 'Shishui SK' in Welsh
+	When I click Continue button from What is your full name page in Welsh
+	Then I should navigate to Pets Owner address postcode page in Welsh
+	When I click 'English' link to change the language
+	Then I should navigate to Pets Owner address postcode page
+	When I click 'Cymraeg' link to change the language
+	Then I should navigate to Pets Owner address postcode page in Welsh
+	And I provided the postcode 'CV1 4PY'
+	When I click Search button
+	Then I should navigate to Pets Owner address page 'Beth yw’ch cyfeiriad?'
+	When I click 'English' link to change the language
+	Then I should navigate to Pets Owner address page 'What is your address?'
+	When I click 'Cymraeg' link to change the language
+	Then I should navigate to Pets Owner address page 'Beth yw’ch cyfeiriad?'
+	And I click on welsh Back button
+	And I should navigate to Pets Owner address postcode page in Welsh
+	When I click on Enter the address manually link from postcode page in Welsh
+	Then I should navigate to Pets Owner manually address page in Welsh
+	When I click 'English' link to change the language
+	Then I should navigate to Pets Owner manually address page
+	When I click 'Cymraeg' link to change the language
+	Then I should navigate to Pets Owner manually address page in Welsh
+	When I fill in 'House 5', 'Uchhiha Road', 'Konoha', 'Zathura', 'RG16BU'and continue in Welsh
+	Then I should navigate to Pets Owner phone number page in Welsh
+	When I click 'English' link to change the language
+	Then I should navigate to Pets Owner phone number page
+	When I click 'Cymraeg' link to change the language
+	Then I should navigate to Pets Owner phone number page in Welsh
+	When I provide Pets Owner '07401659856' and continue in Welsh
+	Then I should redirected to the Is your pet microchipped page in Welsh
+	When I click 'English' link to change the language
+	Then I should redirected to the Is your pet microchipped page
+	When I click 'Cymraeg' link to change the language
+	Then I should redirected to the Is your pet microchipped page in Welsh
+	
+	

--- a/Defra.UI.Tests/Feature/WELSH/Validations/Pet Details Validations Welsh.feature
+++ b/Defra.UI.Tests/Feature/WELSH/Validations/Pet Details Validations Welsh.feature
@@ -523,7 +523,6 @@ Scenario: Verify the hint in breed page for cat
 	When I click on continue button from Is your pet a cat, dog or ferret page in Welsh
 	Then I should redirected to the What breed is your 'Cath'? page in Welsh
 	And I Verify the hint in Breed Page
-	| Yes                      | Yes             | 123456789123456 | Cath | CatBreed |
 
 Scenario Outline: Verify the Welsh language version of each page on selection of Welsh language till the declaration page
 	When I click 'English' link to change the language

--- a/Defra.UI.Tests/Pages/AP/Classes/PetOwnerAddressPage.cs
+++ b/Defra.UI.Tests/Pages/AP/Classes/PetOwnerAddressPage.cs
@@ -29,7 +29,7 @@ namespace Defra.UI.Tests.Pages.AP.Classes
         private IWebElement txtTownOrCity => _driver.WaitForElement(By.Id("TownOrCity"));
         private IWebElement txtCounty => _driver.WaitForElement(By.Id("County"));
         private IReadOnlyCollection<IWebElement> lblErrorMessages => _driver.WaitForElements(By.XPath("//div[@class='govuk-error-summary__body']//a"));
-
+        private IWebElement addressPageHeader => _driver.WaitForElement(By.XPath("//h1/label"));
         #endregion
 
         #region Methods
@@ -94,6 +94,10 @@ namespace Defra.UI.Tests.Pages.AP.Classes
             return false;
         }
 
+        public bool IsAddressPageHeaderDisplayed(string title)
+        {
+            return addressPageHeader.Text.Contains(title);
+        }
         #endregion
     }
 }

--- a/Defra.UI.Tests/Pages/AP/Interfaces/IPetOwnerAddressPage.cs
+++ b/Defra.UI.Tests/Pages/AP/Interfaces/IPetOwnerAddressPage.cs
@@ -13,5 +13,6 @@ namespace Defra.UI.Tests.Pages.AP.Interfaces
         void ClickICannotFindTheAddressInTheListLink();
         void EnterAddressManually(string addressLine1, string addressLine2, string town, string county, string postCode);
         bool IsError(string errorMessage);
+        bool IsAddressPageHeaderDisplayed(string title);
     }
 }

--- a/Defra.UI.Tests/Pages/WELSH/Classes/PetOwnerAddressPageWelsh.cs
+++ b/Defra.UI.Tests/Pages/WELSH/Classes/PetOwnerAddressPageWelsh.cs
@@ -27,7 +27,7 @@ namespace Defra.UI.Tests.Pages.WELSH.Classes
         private IWebElement txtTownOrCity => _driver.WaitForElement(By.Id("TownOrCity"));
         private IWebElement txtCounty => _driver.WaitForElement(By.Id("County"));
         private IReadOnlyCollection<IWebElement> lblErrorMessages => _driver.WaitForElements(By.XPath("//div[@class='govuk-error-summary__body']//a"));
-
+        
         #endregion
 
         #region Methods

--- a/Defra.UI.Tests/Steps/AP/PetBreedPageSteps.cs
+++ b/Defra.UI.Tests/Steps/AP/PetBreedPageSteps.cs
@@ -17,6 +17,7 @@ namespace Defra.UI.Tests.Steps.AP
             _objectContainer = container;
         }
 
+        [Then(@"I Verify the header of the breed page for {string}")]
         [Then(@"I should navigate to What breed is your '([^']*)' page")]
         public void ThenIShouldNavigateToWhatBreedIsYourPage(string petType)
         {

--- a/Defra.UI.Tests/Steps/AP/PetOwnerAddressPageSteps.cs
+++ b/Defra.UI.Tests/Steps/AP/PetOwnerAddressPageSteps.cs
@@ -23,5 +23,11 @@ namespace Defra.UI.Tests.Steps.AP
             PetOwnerAddressPage?.SelectAnAddress(3);
             PetOwnerAddressPage?.ClickContinueButton();
         }
+
+        [Then(@"I should navigate to Pets Owner address page '(.*)'")]
+        public void ThenIShouldNavigateToPetOwnerAddressPage(string title)
+        {
+            Assert.IsTrue(PetOwnerAddressPage?.IsAddressPageHeaderDisplayed(title), $"The page {title} not loaded!");
+        }
     }
 }

--- a/Defra.UI.Tests/Steps/WELSH/PetDetailsWelshSteps.cs
+++ b/Defra.UI.Tests/Steps/WELSH/PetDetailsWelshSteps.cs
@@ -50,6 +50,7 @@ namespace Defra.UI.Tests.Steps.AP
             petSpeciesPageWelsh?.ClickParhauButton();
         }
 
+        [Then(@"I Verify the header of the breed page for {string} in Welsh")]
         [Then(@"I should redirected to the What breed is your {string}? page in Welsh")]
         public void ThenIShouldRedirectedToTheWhatBreedIsYourPageInWelsh(string petType)
         {
@@ -66,12 +67,12 @@ namespace Defra.UI.Tests.Steps.AP
             breedPageWelsh?.ClickParhauButton();
         }
 
-               [Then(@"I have provided freetext breed as '([^']*)' in Welsh")]
-                public void ThenIHaveProvidedFreetextBreedAs(string breed)
-                {
-                    breedPageWelsh?.EnterFreeTextBreed(breed);
-                    _scenarioContext.Add("Brid", breed);
-                }
+        [Then(@"I have provided freetext breed as '([^']*)' in Welsh")]
+        public void ThenIHaveProvidedFreetextBreedAs(string breed)
+        {
+            breedPageWelsh?.EnterFreeTextBreed(breed);
+            _scenarioContext.Add("Brid", breed);
+        }
 
 
         [Then(@"I should redirected to the What is your pet's name page in Welsh")]

--- a/Defra.UI.Tests/Steps/WELSH/PetOwnerDetailsPageWelshSteps.cs
+++ b/Defra.UI.Tests/Steps/WELSH/PetOwnerDetailsPageWelshSteps.cs
@@ -24,7 +24,7 @@ namespace Defra.UI.Tests.Steps.WELSH
         [Then(@"I should navigate to the Pets Owner details correct page in Welsh")]
         public void ThenIShouldNavigateToThePetsOwnerDetailsCorrectPage()
         {
-            var pageTitle = "Are your details correct?";
+            var pageTitle = "Ydy’ch manylion chi’n gywir?";
             Assert.IsTrue(PetOwnerDetailsPageWelsh?.IsNextPageLoaded(pageTitle), $"The page {pageTitle} not loaded!");
         }
 


### PR DESCRIPTION
Test Cases Included:
1. Verify the Welsh language version of each page on selection of Welsh language using Manual Address
2. Verify the Welsh language version of each page on selection of Welsh language till the declaration page

The above test cases validates each page of AP application for the above mentioned flow and checks Welsh to English and vice versa page title checks.